### PR TITLE
Filter now returns a LogStash::Event according to the new logstash model...

### DIFF
--- a/lib/logstash/filters/zeromq.rb
+++ b/lib/logstash/filters/zeromq.rb
@@ -2,6 +2,7 @@
 require "logstash/filters/base"
 require "logstash/namespace"
 require "logstash/json"
+require "logstash/event"
 
 # ZeroMQ filter. This is the best way to send an event externally for filtering
 # It works much like an exec filter would by sending the event "offsite"
@@ -194,7 +195,7 @@ class LogStash::Filters::ZeroMQ < LogStash::Filters::Base
         filter_matched(event)
       else
         reply = LogStash::Json.load(reply)
-        event.overwrite(reply)
+        event.overwrite(LogStash::Event.new(reply))
       end
       filter_matched(event)
       #if message send/recv was not successful add the timeout


### PR DESCRIPTION
https://github.com/logstash-plugins/logstash-filter-zeromq/issues/2 It should fix this issue.