### PR TITLE
update ffi-rzmq dependency

### DIFF
--- a/logstash-filter-zeromq.gemspec
+++ b/logstash-filter-zeromq.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-zeromq'
-  s.version         = '0.1.5'
+  s.version         = '0.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "ZeroMQ filter. This is a way to send an event externally for filtering"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
-  s.add_runtime_dependency 'ffi-rzmq', ['1.0.0']
+  s.add_runtime_dependency 'ffi-rzmq', '~> 2.0.4'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
same ffi-rzmq dependency version as with the zeromq input and output plugins and bump version to 0.1.6