### PR TITLE
Encapsulate the reply in an event object

### DIFF
--- a/lib/logstash/filters/zeromq.rb
+++ b/lib/logstash/filters/zeromq.rb
@@ -192,7 +192,7 @@ class LogStash::Filters::ZeroMQ < LogStash::Filters::Base
         event[@field] = event.sprintf(reply)
         filter_matched(event)
       else
-        reply = LogStash::Json.load(reply)
+        reply = LogStash::Event.new(LogStash::Json.load(reply))
         event.overwrite(reply)
       end
       filter_matched(event)


### PR DESCRIPTION
When the whole event is used, only the @data portion of the event object is passed via 0MQ. Going on the premise that the 0MQ server should return the same object type that it receives, the reply needs to be encapsulated in an event object in order for the overwrite method to be successful.